### PR TITLE
Abstract container in NodeState

### DIFF
--- a/src/ntree.rs
+++ b/src/ntree.rs
@@ -58,7 +58,7 @@ fn branch_dispatch<P, N>(center: &P, point: &P) -> uint
 
 /// A pure N-dimensional tree
 pub struct PureNTree<P, N, O> {
-    state: NodeState<O, PureNTree<P, N, O>>,
+    state: NodeState<O, Vec<PureNTree<P, N, O>>>,
     center: P,
     width: N,
 }
@@ -161,8 +161,9 @@ impl<P, N, O> ObjectQuery<O> for PureNTree<P, N, O> {
     }
 }
 
-impl<P, N, O> Node<P, N, O> for PureNTree<P, N, O> {
-    fn state(&self) -> &NodeState<O, PureNTree<P, N, O>> {
+impl<P, N, O> Node<P, N, O, Vec<PureNTree<P, N, O>>> for PureNTree<P, N, O> {
+
+    fn state(&self) -> &NodeState<O, Vec<PureNTree<P, N, O>>> {
         &self.state
     }
 
@@ -175,7 +176,7 @@ impl<P, N, O> Node<P, N, O> for PureNTree<P, N, O> {
     }
 }
 
-impl<P, N, O> PureTree<P, N, O> for PureNTree<P, N, O> {}
+impl<P, N, O> PureTree<P, N, O, Vec<PureNTree<P, N, O>>> for PureNTree<P, N, O> {}
 
 
 /// An N-dimensional tree
@@ -183,7 +184,7 @@ impl<P, N, O> PureTree<P, N, O> for PureNTree<P, N, O> {}
 /// This tree does not know the dimension of its point at compile time, as it is
 /// not hard-coded and genericity over constants is unsupported in Rust.
 pub struct NTree<P, N, O, D> {
-    state: NodeState<O, NTree<P, N, O, D>>,
+    state: NodeState<O, Vec<NTree<P, N, O, D>>>,
     center: P,
     width: N,
     data: D,
@@ -325,8 +326,8 @@ impl<P, N, O, D, V> NTree<P, N, O, D>
     }
 }
 
-impl<P, N, O, D> Node<P, N, O> for NTree<P, N, O, D> {
-    fn state(&self) -> &NodeState<O, NTree<P, N, O, D>> {
+impl<P, N, O, D> Node<P, N, O, Vec<NTree<P, N, O, D>>> for NTree<P, N, O, D> {
+    fn state(&self) -> &NodeState<O, Vec<NTree<P, N, O, D>>> {
         &self.state
     }
 
@@ -370,8 +371,8 @@ impl<P, N, O, D> ObjectQuery<O> for NTree<P, N, O, D> {
     }
 }
 
-impl<P, N, O, D> PureTree<P, N, O> for NTree<P, N, O, D> {}
-impl<P, N, O, D> Tree<P, N, O, D> for NTree<P, N, O, D> {}
+impl<P, N, O, D> PureTree<P, N, O, Vec<NTree<P, N, O, D>>> for NTree<P, N, O, D> {}
+impl<P, N, O, D> Tree<P, N, O, Vec<NTree<P, N, O, D>>, D> for NTree<P, N, O, D> {}
 
 
 #[cfg(test)]
@@ -556,7 +557,7 @@ mod test {
         });
         b.iter(|| {
             PureNTree::from_iter_raw(
-                vec.iter().map(|&a| a.clone()),
+                vec.iter().map(|a| a.clone()),
                 Orig::orig(), 2.0,
             )
         })
@@ -574,7 +575,7 @@ mod test {
             ),
         });
         b.iter(||
-            PureNTree::from_iter(vec.iter().map(|&a| a.clone()))
+            PureNTree::from_iter(vec.iter().map(|a| a.clone()))
         )
     }
 
@@ -591,7 +592,7 @@ mod test {
             ),
         });
         b.iter(|| {
-            PureNTree::from_iter(vec.iter().map(|&a| a.clone()))
+            PureNTree::from_iter(vec.iter().map(|a| a.clone()))
         })
     }
 
@@ -608,7 +609,7 @@ mod test {
         });
         b.iter(|| {
             NTree::from_iter(
-                vec.iter().map(|&a| a.clone()),
+                vec.iter().map(|a| a.clone()),
                 (Vec2::new(0.0f64, 0.0), 0.0f64),
                 |obj| (obj.position.to_vec() * obj.object, obj.object),
                 |&(mps, ms), &(mp, m)| (mps + mp, ms + m)
@@ -629,7 +630,7 @@ mod test {
         });
         b.iter(|| {
             NTree::from_iter_raw(
-                vec.iter().map(|&a| a.clone()),
+                vec.iter().map(|a| a.clone()),
                 Orig::orig(), 2.0,
                 (Vec2::new(0.0f64, 0.0), 0.0f64),
                 |obj| (obj.position.to_vec() * obj.object, obj.object),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -6,14 +6,11 @@
 /// a list of other nodes. This enum encodes these states and the data
 /// associated with each of them.
 ///
-/// TODO: abstract over this, so that it works different structural
-/// representations
-///
 /// # Type parameters
 ///
 /// - `O` is the type of object stored in the tree structure.
-/// - `N` is the type of the node/tree structure.
-pub enum NodeState<O, N> {
+/// - `C` is a collection of nodes in a branch.
+pub enum NodeState<O, C> {
 
     /// An empty node does not contain any object
     Empty,
@@ -21,8 +18,8 @@ pub enum NodeState<O, N> {
     /// A leaf node contains exactly one object
     Leaf(O),
 
-    /// A branch node contains a heap-allocated vector of nodes
-    Branch(Vec<N>),
+    /// A branch node contains a collection of nodes
+    Branch(C),
 }
 
 
@@ -89,10 +86,10 @@ pub trait ObjectQuery<O> {
 ///
 /// This is part of the essential features of a tree. Note that both a whole
 /// tree and its constituents implement this.
-pub trait Node<P, N, O> {
+pub trait Node<P, N, O, C> {
 
     /// The state of the node
-    fn state(&self) -> &NodeState<O, Self>;
+    fn state(&self) -> &NodeState<O, C>;
 
     /// The center point of the node
     fn center(&self) -> &P;
@@ -121,7 +118,7 @@ pub trait AssociatedData<D> {
 /// - `N` is the scalar of the vector space of points.
 /// - The tree stores objects of type `O`. These objects need to have some
 ///   notion of a position.
-pub trait PureTree<P, N, O>: ObjectQuery<O> + Node<P, N, O> {}
+pub trait PureTree<P, N, O, C>: ObjectQuery<O> + Node<P, N, O, C> {}
 
 
 /// A spatial tree with associated data
@@ -136,4 +133,4 @@ pub trait PureTree<P, N, O>: ObjectQuery<O> + Node<P, N, O> {}
 ///   notion of a position.
 /// - `D` is the kind of data associated with each node. This is computed
 ///   recursively during tree construction.
-pub trait Tree<P, N, O, D>: DataQuery<D> + AssociatedData<D> + PureTree<P, N, O> {}
+pub trait Tree<P, N, O, C, D>: DataQuery<D> + AssociatedData<D> + PureTree<P, N, O, C> {}


### PR DESCRIPTION
NodeState is not hard-coded to use a Vec any more. For generic programming we may want to impose trait bounds on the container in the future.

Fixes #7.
