### PR TITLE
Reduce quickcheck to a dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ debug = false
 [dependencies.nalgebra]
 git = "https://github.com/sebcrozet/nalgebra"
 
-[dependencies.quickcheck]
+[dev-dependencies.quickcheck]
 git = "https://github.com/BurntSushi/quickcheck"
 
-[dependencies.quickcheck_macros]
+[dev-dependencies.quickcheck_macros]
 git = "https://github.com/BurntSushi/quickcheck"


### PR DESCRIPTION
Users of acacia should not need to be aware of its testing infrastructure and currently acacia does not implement quickcheck traits to export.
